### PR TITLE
Update timegan.py

### DIFF
--- a/lib/timegan.py
+++ b/lib/timegan.py
@@ -228,7 +228,7 @@ class BaseModel():
       return None, None
     ## Synthetic data generation
     self.X0, self.T = batch_generator(self.ori_data, self.ori_time, self.opt.batch_size)
-    self.Z = random_generator(num_samples, self.opt.z_dim, self.T, self.max_seq_len, mean, std)
+    self.Z = random_generator(num_samples, self.opt.z_dim, self.T, self.max_seq_len)
     self.Z = torch.tensor(self.Z, dtype=torch.float32).to(self.device)
     self.E_hat = self.netg(self.Z)    # [?, 24, 24]
     self.H_hat = self.nets(self.E_hat)  # [?, 24, 24]


### PR DESCRIPTION
In the progress of generation, # self.Z = random_generator(num_samples, self.opt.z_dim, self.T, self.max_seq_len, mean, std) should remove two extra arguments "mean, std".
   